### PR TITLE
Adding a trait keyword

### DIFF
--- a/src/test/org/codehaus/groovy/transform/TraitASTTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/TraitASTTransformationTest.groovy
@@ -16,11 +16,6 @@
 
 package org.codehaus.groovy.transform
 
-import groovy.transform.CompileStatic
-import groovy.transform.Trait
-
-import java.lang.invoke.MethodHandles
-
 class TraitASTTransformationTest extends GroovyTestCase {
     void testTraitWithNoMethod() {
         assertScript '''
@@ -157,7 +152,7 @@ class TraitASTTransformationTest extends GroovyTestCase {
     }
 
     void testTraitWithField2() {
-        assertScript '''import org.codehaus.groovy.transform.TraitASTTransformationTest.TestTrait2 as TestTrait2
+        assertScript '''import org.codehaus.groovy.transform.TestTrait2 as TestTrait2
         class Foo implements TestTrait2 {
             def cat() { "cat" }
         }
@@ -228,18 +223,16 @@ class TraitASTTransformationTest extends GroovyTestCase {
         '''
     }
 
-
-    static trait TestTrait2 {
-        private String message = 'Hello'
-        String getMessage() { this.message }
-        String blah() { message }
-        def meow() {
-            "Meow! I'm a ${cat()}"
-        }
-    }
-
-
     static trait TestTrait {
         int a() { 123 }
+    }
+}
+
+trait TestTrait2 {
+    private String message = 'Hello'
+    String getMessage() { this.message }
+    String blah() { message }
+    def meow() {
+        "Meow! I'm a ${cat()}"
     }
 }


### PR DESCRIPTION
Experiment at introducing a `trait` keyword.

Beware there's still a problem with the tests involving the usage of precompiled traits, but I haven't figured out why.
It's complaining about the presence of the `__$stMC` field.
If I temporarily remove that check from the `Verifier` on line 191, I then get another problem afterwards with the following message:
    java.lang.IncompatibleClassChangeError: Found interface org.codehaus.groovy.transform.TestTrait2, but class was expected

Also we'll need to refactor the `traitDefinition` production in `groovy.g` as it's currently a mere copy of `classDefinition`. So duplication should be avoided.
